### PR TITLE
[Core] (Feature) Allow importing folders using `im` command

### DIFF
--- a/SomewhereStandard/StringHelper.cs
+++ b/SomewhereStandard/StringHelper.cs
@@ -150,6 +150,18 @@ namespace StringHelper
                 .Replace('"', '_'))
             .Where(t => !string.IsNullOrEmpty(t))  // Skip empty or white space entries
             ?? new string[] { };    // Return empty for null string
+        /// <summary>
+        /// Split a path as tags, lower cased
+        /// </summary>
+        public static IEnumerable<string> SplitDirectoryAsTags(this string path)
+            => path?.GetRealDirectoryPath().Split(new char[] { '\\', '/' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(d => 
+                // Save as lower case
+                d.Trim().ToLower()
+                // Replace double quote (not allowed in Windows, allowed in Linux) with underscore
+                .Replace('"', '_'))
+            .Where(t => !string.IsNullOrEmpty(t))  // Skip empty or white space entries
+            ?? new string[] { };    // Return empty for null string
     }
 
     /// <summary>
@@ -165,6 +177,7 @@ namespace StringHelper
         /// </summary>
         public static string AppendSeparator(this string folderPath, char preferred = '/')
         {
+            if (string.IsNullOrWhiteSpace(folderPath)) return folderPath;
             char last = folderPath.Last();
             if (!last.IsSeparator() && last != ':')
                 return folderPath + (folderPath.First().IsSeparator() ? folderPath.First() : preferred);
@@ -243,7 +256,6 @@ namespace StringHelper
             }
             return root.AppendSeparator();
         }
-
         /// <summary>
         /// Get the protocol part of a path if it contains protocol, otherwise return null
         /// </summary>
@@ -304,6 +316,11 @@ namespace StringHelper
             else
                 return false;
         }
+        /// <summary>
+        /// Checks whether the path ends with a folder separator
+        /// </summary>
+        public static bool IsPathFolder(this string path)
+            => path.Last().IsSeparator();
         /// <summary>
         /// Get the path to directory without protocol and filename;
         /// This function works for both seperators;
@@ -383,7 +400,7 @@ namespace StringHelper
             // Enumerate
             int lastIndex = remaining.Length - 1;
             bool folderState = true;
-            int lastFolderEndingIndex = 0;
+            int lastFolderEndingIndex = -1;
             string lastFoldername = string.Empty;
             string realFilename = string.Empty;
             for (int i = 0; i < remaining.Length; i++)

--- a/SomewhereTest/DBTest.cs
+++ b/SomewhereTest/DBTest.cs
@@ -27,6 +27,7 @@ namespace SomewhereTest
         [Fact]
         public void AddFileShoudWorkWithFilesInsideSubfolders()
         {
+            // Add files should be able to add paths that are inside subfolders of Home directory
             throw new NotImplementedException();
         }
         [Fact]
@@ -304,7 +305,7 @@ namespace SomewhereTest
             Commands.New();
             Commands.Doc("File.txt");
             Commands.Add("File.txt");
-            string longItemName = @"This is /my file/ in Somewhere 
+            string longItemName = @"This is folder /my folder/ In Somewhere 
 so I should be able to do <anything> I want with it \\including ""!!!!????**********""
 This is /my file/ in Somewhere 
 so I should be able to do <anything> I want with it \\including ""!!!!????**********""
@@ -324,9 +325,9 @@ This is /my file/ in Somewhere
 so I should be able to do <anything> I want with it \\including ""!!!!????**********""
 This is /my file/ in Somewhere 
 so I should be able to do <anything> I want with it \\including ""!!!!????**********"".txt";
-            Commands.MoveFileInHomeFolder(Commands.GetFileID("File.txt").Value, "File.txt", longItemName);
+            Commands.MV("File.txt", longItemName);
             string escapedName = // A simple very specific logic for expected properly formatted name string
-                longItemName.Substring(0, 260 - 1 /* Trailing null */ - Directory.GetCurrentDirectory().Length)
+                longItemName.Substring(27 /*Skip folder part*/, 260 - 1 /* Trailing null */ - Directory.GetCurrentDirectory().Length)
                 .Replace('/', '_')
                 .Replace('<', '_')
                 .Replace('>', '_')
@@ -336,8 +337,8 @@ so I should be able to do <anything> I want with it \\including ""!!!!????******
                 .Replace('*', '_')
                 .Replace('\r', '_')
                 .Replace('\n', '_');
-            string escaped = Commands.GetPhysicalName(longItemName);
-            Assert.True(escapedName.IndexOf(escaped.Substring(0, escaped.Length - "...txt".Length)) == 0);
+            string escaped = Commands.GetPhysicalNameForFilesThatCanBeInsideFolder(longItemName);
+            Assert.True(("This is folder /my folder/ " + escapedName).IndexOf(escaped.Substring(0, escaped.Length - "...txt".Length)) == 0);
             Assert.True(Helper.TestFileExists(escaped));
             // Clean up
             Commands.Dispose();
@@ -352,7 +353,7 @@ so I should be able to do <anything> I want with it \\including ""!!!!????******
             Commands.New();
             Commands.Doc("File.txt");
             Commands.Doc("File_.txt");
-            Assert.Equal("File_#1.txt", Commands.GetNewPhysicalName("File*.txt", 1));
+            Assert.Equal("File_#1.txt", Commands.GetNewPhysicalName("File*.txt", 1, null));
             // Clean up
             Commands.Dispose();
             Helper.CleanTestFolderRemoveAllFiles();
@@ -375,15 +376,15 @@ so I should be able to do <anything> I want with it \\including ""!!!!????******
             Helper.CleanTestFolderRemoveAllFiles();
         }
         [Fact]
-        public void MoveFileInHomeFolderShouldHandleInvalidCharacterEscape()
+        public void MoveFileShouldHandleInvalidCharacterEscape()
         {
             Helper.CleanOrCreateTestFolderRemoveAllFiles();
             Commands Commands = Helper.CreateNewCommands();
             Commands.New();
             Commands.Doc("test.txt");
             Commands.Add("test.txt");
-            Commands.MoveFileInHomeFolder(1 /* Expected ID for new DB */, "test.txt", "test*.txt");
-            Commands.MoveFileInHomeFolder(1, "test*.txt", "test*//WOW.");
+            Commands.MV("test.txt", "test*.txt");
+            Commands.MV("test*.txt", "test*//WOW.");
             Assert.True(Helper.TestFileExists("test___WOW"));  // Notice this is not user level detail but is documented and standardized
             // Clean up
             Commands.Dispose();
@@ -402,7 +403,7 @@ so I should be able to do <anything> I want with it \\including ""!!!!????******
             Helper.CleanTestFolderRemoveAllFiles();
         }
         [Fact]
-        public void MoveFileInHomeFolderShouldHandleNameCollisionGracefully()
+        public void MoveFileShouldHandleNameCollisionGracefully()
         {
             Helper.CleanOrCreateTestFolderRemoveAllFiles();
             Commands Commands = Helper.CreateNewCommands();
@@ -410,7 +411,7 @@ so I should be able to do <anything> I want with it \\including ""!!!!????******
             Commands.Doc("test.txt");
             Commands.Add("test.txt");
             Commands.Doc("test_.txt"); // Represent a manually added, non-managed file which can collide with managed file later
-            Commands.MoveFileInHomeFolder(Commands.GetFileID("test.txt").Value, "test.txt", "test*.txt");
+            Commands.MV("test.txt", "test*.txt");
             Assert.True(Helper.TestFileExists("test_#1.txt"));  // Notice this is not user level detail but is documented and standardized
             // Clean up
             Commands.Dispose();

--- a/SomewhereTest/FilenameTest.cs
+++ b/SomewhereTest/FilenameTest.cs
@@ -21,6 +21,7 @@ namespace SomewhereTest
             Commands Commands = Helper.CreateNewCommands();
             Commands.New();
             Commands.Doc("test.txt");
+            Commands.Add("test.txt");
             Commands.MV("test.txt", "folder1/folder2\\test*.txt");   // Name containing invalid characters
             // Clean up
             Commands.Dispose();

--- a/SomewhereTest/Helper.cs
+++ b/SomewhereTest/Helper.cs
@@ -54,12 +54,15 @@ namespace SomewhereTest
         /// </summary>
         public static string GetFilePath(string fileName, [CallerMemberName] string unitTestFolderName = null)
             => Path.Combine(unitTestFolderName, fileName);
+        /// <summary>
+        /// Get actual path for a folder relative to the unit test
+        /// </summary>
         public static string GetFolderPath(string folderName, [CallerMemberName] string unitTestFolderName = null)
             => GetFilePath(folderName, unitTestFolderName);
         /// <summary>
         /// Get full path to unit test folder
         /// </summary>
-        public static string GetFolderPath([CallerMemberName] string unitTestFolderName = null)
+        public static string GetTestFolderPath([CallerMemberName] string unitTestFolderName = null)
             => Path.GetFullPath(unitTestFolderName);
         public static void CreateEmptyFile(string fileName, [CallerMemberName] string unitTestFolderName = null)
             => File.Create(Path.Combine(unitTestFolderName, fileName)).Dispose();

--- a/SomewhereTest/ImportExportTest.cs
+++ b/SomewhereTest/ImportExportTest.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Somewhere;
+using System.IO;
+using System.Linq;
+using StringHelper;
+
+namespace SomewhereTest
+{
+    public class ImportExportTest
+    {
+        [Fact]
+        public void ImportExternalFolderShouldMakeCopy()
+        {
+            void InitializeExternalTestFiles(string dir, Commands commands)
+            {
+                if (!Directory.Exists(dir)) // Unit test working directory
+                {
+                    Directory.CreateDirectory(dir);
+                    Directory.CreateDirectory(Path.Combine(dir, "subFolder"));
+                    commands.Doc("File.txt"); // Create file for test
+                    commands.Doc("File2.txt"); // Create file for test
+                    commands.Doc("File3.txt"); // Create file for test
+                    
+                    // Move from Home to external path
+                    File.Move(Helper.GetFilePath("File.txt"), Path.Combine(dir, "File.txt"));
+                    File.Move(Helper.GetFilePath("File2.txt"), Path.Combine(dir, "File2.txt"));
+                    File.Move(Helper.GetFilePath("File3.txt"), Path.Combine(dir, "subFolder", "File3.txt"));
+                }
+            }
+            void ValidateTestFileExistence(string dir, bool flattened = false)
+            {
+                string file1 = Path.Combine(dir, "File.txt");
+                string file2 = Path.Combine(dir, "File2.txt");
+                string file3 = flattened 
+                    ? Path.Combine(dir, "File3.txt")
+                    : Path.Combine(dir, "subFolder", "File3.txt");
+                Assert.True(File.Exists(Path.GetFullPath(file1)));
+                Assert.True(File.Exists(Path.GetFullPath(file2)));
+                Assert.True(File.Exists(Path.GetFullPath(file3)));
+            }
+
+            // Create commands object
+            Helper.CleanOrCreateTestFolderRemoveAllFiles();
+            Commands Commands = Helper.CreateNewCommands();
+            Commands.New();
+            // Initialize external folder
+            string externalDir = "ImportExternalFolderShouldMakeCopyExternal";  // Inside working directory
+            InitializeExternalTestFiles(externalDir, Commands);
+            // Validate file existences independently inside external folder
+            ValidateTestFileExistence(externalDir);
+            // Perform import operation
+            Commands.Im(Path.GetFullPath(externalDir)); // Add using full path for foreign directory
+            // Validate external files still exist
+            ValidateTestFileExistence(externalDir);
+            // Validate files are copied to interal folder, flattned
+            ValidateTestFileExistence(Commands.HomeDirectory, true);
+            // Assert added name is relative
+            Assert.Empty(new string[] { "File.txt", "File2.txt", "File3.txt" }.Except(
+                Commands.GetAllFiles().Select(f => f.Name)));
+            // Assert tags
+            var expectedTags = Path.GetFullPath(Path.Combine(externalDir, "subFolder")).SplitDirectoryAsTags();
+            var realTags = Commands.GetAllTags().Select(t => t.Name);
+            Assert.Empty(expectedTags.Except(realTags));
+            // Clean up
+            Commands.Dispose();
+            Helper.CleanTestFolderRemoveAllFiles();
+            Helper.CleanTestFolderRemoveAllFiles(externalDir);
+        }
+        [Fact]
+        public void ImportExternalFolderShouldHandleConflictNameByDontChangeFiles()
+        {
+            void InitializeExternalTestFiles(string dir, Commands commands)
+            {
+                if (!Directory.Exists(dir)) // Unit test working directory
+                {
+                    Directory.CreateDirectory(dir);
+                    Directory.CreateDirectory(Path.Combine(dir, "subFolder"));
+                    commands.Doc("File.txt"); // Create file for test
+                    commands.Doc("File2.txt"); // Create file for test
+                    commands.Doc("File3.txt"); // Create file for test
+
+                    // Move from Home to external path
+                    File.Move(Helper.GetFilePath("File.txt"), Path.Combine(dir, "File.txt"));
+                    File.Move(Helper.GetFilePath("File2.txt"), Path.Combine(dir, "File2.txt"));
+                    File.Move(Helper.GetFilePath("File3.txt"), Path.Combine(dir, "subFolder", "File3.txt"));
+                }
+            }
+            void ValidateTestFileExistence(string dir, bool flattened = false)
+            {
+                string file1 = Path.Combine(dir, "File.txt");
+                string file2 = Path.Combine(dir, "File2.txt");
+                string file3 = flattened
+                    ? Path.Combine(dir, "File3.txt")
+                    : Path.Combine(dir, "subFolder", "File3.txt");
+                Assert.True(File.Exists(Path.GetFullPath(file1)));
+                Assert.True(File.Exists(Path.GetFullPath(file2)));
+                Assert.True(File.Exists(Path.GetFullPath(file3)));
+            }
+
+            // Create commands object
+            Helper.CleanOrCreateTestFolderRemoveAllFiles();
+            Commands Commands = Helper.CreateNewCommands();
+            Commands.New();
+            // Initialize external folder
+            string externalDir = "ImportExternalFolderShouldMakeCopyExternal";  // Inside working directory
+            InitializeExternalTestFiles(externalDir, Commands);
+            // Validate file existences independently inside external folder
+            ValidateTestFileExistence(externalDir);
+            // Add a potentially duplicate file name
+            Commands.Doc("File.txt");
+            // Perform import operation
+            Commands.Im(Path.GetFullPath(externalDir)); // Add using full path for foreign directory
+            // Validate external files still exist
+            ValidateTestFileExistence(externalDir);
+            // Validate files are copied to interal folder, flattned
+            ValidateTestFileExistence(Commands.HomeDirectory, true);
+            // Assert added name is relative and File.txt is not added
+            Assert.Empty(new string[] { "File2.txt", "File3.txt" }.Except(
+                Commands.GetAllFiles().Select(f => f.Name)));
+            // Assert tags
+            var expectedTags = Path.GetFullPath(Path.Combine(externalDir, "subFolder")).SplitDirectoryAsTags();
+            var realTags = Commands.GetAllTags().Select(t => t.Name);
+            Assert.Empty(expectedTags.Except(realTags));
+            // Clean up
+            Commands.Dispose();
+            Helper.CleanTestFolderRemoveAllFiles();
+            Helper.CleanTestFolderRemoveAllFiles(externalDir);
+        }
+        [Fact]
+        public void ImportInternalFolderShouldCut()
+        {
+            void InitializeInternalTestFiles(Commands commands)
+            {
+                string fullPath = Helper.GetFolderPath("subFolder");
+                if (!Directory.Exists(fullPath)) // A subdir inside test folder
+                {
+                    Directory.CreateDirectory(fullPath);
+                    Directory.CreateDirectory(Path.Combine(fullPath, "subFolder2")); // Another subFolder
+                    commands.Doc("File.txt"); // Create file for test
+                    commands.Doc("File2.txt"); // Create file for test
+                    commands.Doc("File3.txt"); // Create file for test
+
+                    // Move from Home to subDir path
+                    File.Move(Helper.GetFilePath("File.txt"), Path.Combine(fullPath, "File.txt"));
+                    File.Move(Helper.GetFilePath("File2.txt"), Path.Combine(fullPath, "File2.txt"));
+                    File.Move(Helper.GetFilePath("File3.txt"), Path.Combine(fullPath, "subFolder2", "File3.txt"));
+                }
+            }
+            void ValidateTestFileExistence(string path, bool assertExist = true, bool flattened = false)
+            {
+                string fullPath = Path.GetFullPath(path);
+                string file1 = Path.Combine(fullPath, "File.txt");
+                string file2 = Path.Combine(fullPath, "File2.txt");
+                string file3 = flattened
+                    ? Path.Combine(fullPath, "File3.txt")
+                    : Path.Combine(fullPath, "subFolder2", "File3.txt");
+                Assert.True(assertExist ? File.Exists(Path.GetFullPath(file1)) : !File.Exists(Path.GetFullPath(file1)));
+                Assert.True(assertExist ? File.Exists(Path.GetFullPath(file2)) : !File.Exists(Path.GetFullPath(file2)));
+                Assert.True(assertExist ? File.Exists(Path.GetFullPath(file3)) : !File.Exists(Path.GetFullPath(file3)));
+            }
+
+            // Create commands object
+            Helper.CleanOrCreateTestFolderRemoveAllFiles();
+            Commands Commands = Helper.CreateNewCommands();
+            Commands.New();
+            // Initialize internal folder
+            InitializeInternalTestFiles(Commands);
+            // Validate file existences independently inside external folder
+            ValidateTestFileExistence(Helper.GetFolderPath("subFolder"));
+            // Perform import operation
+            Commands.Im(Path.GetFullPath(Helper.GetFolderPath("subFolder"))); // Test adding using full path for internal directory
+            // Validate internal files no longer exist
+            ValidateTestFileExistence(Helper.GetFolderPath("subFolder"), false);
+            // Validate files are copied to interal folder, flattned
+            ValidateTestFileExistence(Commands.HomeDirectory, true, true);
+            // Assert added name is relative
+            Assert.Empty(new string[] { "File.txt", "File2.txt", "File3.txt" }.Except(
+                Commands.GetAllFiles().Select(f => f.Name)));
+            // Assert tags
+            var expectedTags = Path.GetFullPath(Helper.GetFolderPath(Path.Combine("subFolder", "subFolder2"))).SplitDirectoryAsTags();
+            var actualTags = Commands.GetAllTags().Select(t => t.Name);
+            Assert.Empty(expectedTags.Except(actualTags));
+            // Clean up
+            Commands.Dispose();
+            Helper.CleanTestFolderRemoveAllFiles();
+        }
+        [Fact]
+        public void ImportInternalFolderShouldCutHandleAlreadyMangedFilesProperly()
+        {
+            void InitializeInternalTestFiles(Commands commands)
+            {
+                string fullPath = Helper.GetFolderPath("subFolder");
+                if (!Directory.Exists(fullPath)) // A subdir inside test folder
+                {
+                    Directory.CreateDirectory(fullPath);
+                    Directory.CreateDirectory(Path.Combine(fullPath, "subFolder2")); // Another subFolder
+                    commands.Doc("File.txt"); // Create file for test
+                    commands.Doc("File2.txt"); // Create file for test
+                    commands.Doc("File3.txt"); // Create file for test
+
+                    // Move from Home to subDir path
+                    File.Move(Helper.GetFilePath("File.txt"), Path.Combine(fullPath, "File.txt"));
+                    File.Move(Helper.GetFilePath("File2.txt"), Path.Combine(fullPath, "File2.txt"));
+                    File.Move(Helper.GetFilePath("File3.txt"), Path.Combine(fullPath, "subFolder2", "File3.txt"));
+                }
+            }
+            void ValidateTestFileExistence(string path, bool assertExist = true, bool flattened = false)
+            {
+                string fullPath = Path.GetFullPath(path);
+                string file1 = Path.Combine(fullPath, "File.txt");
+                string file2 = Path.Combine(fullPath, "File2.txt");
+                string file3 = flattened
+                    ? Path.Combine(fullPath, "File3.txt")
+                    : Path.Combine(fullPath, "subFolder2", "File3.txt");
+                Assert.True(assertExist ? File.Exists(Path.GetFullPath(file1)) : !File.Exists(Path.GetFullPath(file1)));
+                Assert.True(assertExist ? File.Exists(Path.GetFullPath(file2)) : !File.Exists(Path.GetFullPath(file2)));
+                Assert.True(assertExist ? File.Exists(Path.GetFullPath(file3)) : !File.Exists(Path.GetFullPath(file3)));
+            }
+
+            // Create commands object
+            Helper.CleanOrCreateTestFolderRemoveAllFiles();
+            Commands Commands = Helper.CreateNewCommands();
+            Commands.New();
+            // Initialize internal folder
+            InitializeInternalTestFiles(Commands);
+            // Validate file existences independently inside external folder
+            ValidateTestFileExistence(Helper.GetFolderPath("subFolder"));
+            // Add a file inside folder explicitly
+            Commands.Add(Path.Combine("subFolder", "File.txt"));
+            Assert.Single(Commands.GetAllFiles());
+            // Perform import operation
+            Commands.Im(Path.GetFullPath(Helper.GetFolderPath("subFolder"))); // Test adding using full path for internal directory
+            // Validate internal files no longer exist
+            ValidateTestFileExistence(Helper.GetFolderPath("subFolder"), false);
+            // Validate files are copied to interal folder, flattned
+            ValidateTestFileExistence(Commands.HomeDirectory, true, true);
+            // Assert added name is relative
+            Assert.Empty(new string[] { "File.txt", "File2.txt", "File3.txt" }.Except(
+                Commands.GetAllFiles().Select(f => f.Name)));
+            // Clean up
+            Commands.Dispose();
+            Helper.CleanTestFolderRemoveAllFiles();
+        }
+    }
+}

--- a/SomewhereTest/InputOutputTest.cs
+++ b/SomewhereTest/InputOutputTest.cs
@@ -28,7 +28,7 @@ namespace SomewhereTest
             var info = new ProcessStartInfo()
             {
                 FileName = "somewhere", // Notice this unit test require PATH is set so this executable can be found
-                WorkingDirectory = Helper.GetFolderPath(),
+                WorkingDirectory = Helper.GetTestFolderPath(),
                 UseShellExecute = false,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,


### PR DESCRIPTION
- [Core] (Improvement) Improve handling of itemnames with folder paths for `mv` and `rm` command; Generally improve itemname handling consistency;
- [Core] (Bug Fix) Fix an issue with `StringHelper.GetRealFilename()` function when path contains no folder;
- [Test] Update tests for **MoveFile~** related functionality according to new updates to `MoveFileInHomeFolder()` function;
- [Test] Update `GetPhysicalNameShouldProperlyHandleLongNames()` test;
- [Test] Update test helper function names to avoid calling ambiguity;
- [Test] Add tests for Importing from internal and external folders.